### PR TITLE
Fix heavy RAM usage caused by ThaumicReplicator recipe cache list

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,10 +1,10 @@
 // Add your dependencies here
 
 dependencies {
-    compile('com.github.GTNewHorizons:AppleCore:3.3.1:dev')
+    compile('com.github.GTNewHorizons:AppleCore:3.3.3:dev')
     compile('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     compile("curse.maven:witchery-69673:2234410")
-    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-451-GTNH:dev') {
+    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-471-GTNH:dev') {
         transitive = false
     }
     compile('com.github.GTNewHorizons:Baubles:1.0.4:dev') {
@@ -16,7 +16,7 @@ dependencies {
     compile('com.github.GTNewHorizons:CodeChickenLib:1.3.0:dev') {
         transitive = false
     }
-    compileOnly('com.github.GTNewHorizons:ThaumicTinkerer:2.10.1:dev') {
+    compileOnly('com.github.GTNewHorizons:ThaumicTinkerer:2.10.2:dev') {
         transitive = false
     }
     compileOnly("com.github.GTNewHorizons:waila:1.8.1:api") {
@@ -25,6 +25,6 @@ dependencies {
     api ('com.github.GTNewHorizons:ThaumicBoots:1.3.9:dev'){
         exclude group: 'com.github.GTNewHorizons', module: 'Thaumic_Exploration'
     }
-    runtimeOnly("com.github.GTNewHorizons:CodeChickenCore:1.3.7:dev")  // Allow obfuscated Witchery to run in dev
-    runtimeOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.34-GTNH:dev")
+    runtimeOnly("com.github.GTNewHorizons:CodeChickenCore:1.3.9:dev")  // Allow obfuscated Witchery to run in dev
+    runtimeOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.44-GTNH:dev")
 }

--- a/src/main/java/flaxbeard/thaumicexploration/ThaumicExploration.java
+++ b/src/main/java/flaxbeard/thaumicexploration/ThaumicExploration.java
@@ -2,7 +2,6 @@ package flaxbeard.thaumicexploration;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
@@ -20,9 +19,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.common.ForgeChunkManager;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.oredict.OreDictionary;
-
-import org.apache.commons.lang3.tuple.MutablePair;
 
 import baubles.api.BaubleType;
 import cpw.mods.fml.client.registry.RenderingRegistry;
@@ -103,13 +99,11 @@ import flaxbeard.thaumicexploration.wand.WandRodNecromancerOnUpdate;
 import flaxbeard.thaumicexploration.wand.WandRodTransmutationOnUpdate;
 import flaxbeard.thaumicexploration.wand.WandRodTransmutative;
 import thaumcraft.api.ThaumcraftApi;
-import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.wands.StaffRod;
 import thaumcraft.api.wands.WandCap;
 import thaumcraft.api.wands.WandRod;
 import thaumcraft.common.blocks.BlockCandleItem;
 import thaumcraft.common.config.ConfigBlocks;
-import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
 
 @Mod(
         modid = ThaumicExploration.MODID,
@@ -124,7 +118,6 @@ public class ThaumicExploration {
     public static FMLEventChannel channel;
     public static final String MODID = "ThaumicExploration";
 
-    public static ArrayList<MutablePair<Item, Integer>> allowedItems = new ArrayList<MutablePair<Item, Integer>>();
     public static Item pureZombieBrain;
     public static Item blankSeal;
     public static Item chestSeal;
@@ -582,161 +575,6 @@ public class ThaumicExploration {
         ModResearch.initResearch();
         // NecromanticAltarAPI.initNecromanticRecipes();
         proxy.setUnicode();
-
-        allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.stone), 0));
-        String[] ores = OreDictionary.getOreNames();
-        for (String ore : ores) {
-            if (ore != null) {
-                if (ore.equals("logWood")) {
-                    for (ItemStack is : OreDictionary.getOres(ore)) {
-                        AspectList ot = ThaumcraftCraftingManager.getObjectTags(is);
-                        ot = ThaumcraftCraftingManager.getBonusTags(is, ot);
-                        if (!(is.getItem() == Item.getItemFromBlock(ConfigBlocks.blockMagicalLog))
-                                && ot.getAspects().length > 0)
-                            allowedItems.add(MutablePair.of(is.getItem(), is.getItemDamage()));
-                    }
-                }
-                if (ore.equals("treeLeaves")) {
-                    for (ItemStack is : OreDictionary.getOres(ore)) {
-                        AspectList ot = ThaumcraftCraftingManager.getObjectTags(is);
-                        ot = ThaumcraftCraftingManager.getBonusTags(is, ot);
-                        if (!(is.getItem() == Item.getItemFromBlock(ConfigBlocks.blockMagicalLeaves))
-                                && ot.getAspects().length > 0)
-                            allowedItems.add(MutablePair.of(is.getItem(), is.getItemDamage()));
-                    }
-                }
-                if (ConfigTX.allowModWoodReplication) {
-                    if (ConfigTX.allowMagicPlankReplication) {
-                        if (ore.equals("plankWood")) {
-                            for (ItemStack is : OreDictionary.getOres(ore)) {
-                                AspectList ot = ThaumcraftCraftingManager.getObjectTags(is);
-                                ot = ThaumcraftCraftingManager.getBonusTags(is, ot);
-                                if (ot.getAspects().length > 0)
-                                    allowedItems.add(MutablePair.of(is.getItem(), is.getItemDamage()));
-                            }
-                        }
-                    } else {
-                        if (ore.equals("plankWood")) {
-                            for (ItemStack is : OreDictionary.getOres(ore)) {
-                                AspectList ot = ThaumcraftCraftingManager.getObjectTags(is);
-                                ot = ThaumcraftCraftingManager.getBonusTags(is, ot);
-                                if (!(is.getItem() == Item.getItemFromBlock(ConfigBlocks.blockWoodenDevice))
-                                        && ot.getAspects().length > 0)
-                                    allowedItems.add(MutablePair.of(is.getItem(), is.getItemDamage()));
-                            }
-                        }
-                    }
-
-                    if (ore.equals("slabWood")) {
-                        for (ItemStack is : OreDictionary.getOres(ore)) {
-                            AspectList ot = ThaumcraftCraftingManager.getObjectTags(is);
-                            ot = ThaumcraftCraftingManager.getBonusTags(is, ot);
-                            if (ot.getAspects().length > 0)
-                                allowedItems.add(MutablePair.of(is.getItem(), is.getItemDamage()));
-                        }
-                    }
-                    if (ore.equals("stairWood")) {
-                        for (ItemStack is : OreDictionary.getOres(ore)) {
-                            AspectList ot = ThaumcraftCraftingManager.getObjectTags(is);
-                            ot = ThaumcraftCraftingManager.getBonusTags(is, ot);
-                            if (ot.getAspects().length > 0)
-                                allowedItems.add(MutablePair.of(is.getItem(), is.getItemDamage()));
-                        }
-                    }
-                } else {
-                    allowedItems.add(
-                            MutablePair.of(Item.getItemFromBlock(Blocks.wooden_slab), OreDictionary.WILDCARD_VALUE));
-                    allowedItems.add(
-                            MutablePair.of(Item.getItemFromBlock(Blocks.birch_stairs), OreDictionary.WILDCARD_VALUE));
-                    allowedItems.add(
-                            MutablePair.of(Item.getItemFromBlock(Blocks.oak_stairs), OreDictionary.WILDCARD_VALUE));
-                    allowedItems.add(
-                            MutablePair.of(Item.getItemFromBlock(Blocks.jungle_stairs), OreDictionary.WILDCARD_VALUE));
-                    allowedItems.add(
-                            MutablePair.of(Item.getItemFromBlock(Blocks.spruce_stairs), OreDictionary.WILDCARD_VALUE));
-                    allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.log), OreDictionary.WILDCARD_VALUE));
-                    allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.log2), OreDictionary.WILDCARD_VALUE));
-                    allowedItems
-                            .add(MutablePair.of(Item.getItemFromBlock(Blocks.planks), OreDictionary.WILDCARD_VALUE));
-                    if (ConfigTX.allowMagicPlankReplication) {
-                        allowedItems.add(MutablePair.of(Item.getItemFromBlock(ConfigBlocks.blockWoodenDevice), 6));
-                        allowedItems.add(MutablePair.of(Item.getItemFromBlock(ConfigBlocks.blockWoodenDevice), 7));
-                    }
-                }
-                if (ConfigTX.allowModStoneReplication) {
-                    if (ore.equals("stone")) {
-                        for (ItemStack is : OreDictionary.getOres(ore)) {
-                            AspectList ot = ThaumcraftCraftingManager.getObjectTags(is);
-                            ot = ThaumcraftCraftingManager.getBonusTags(is, ot);
-                            if (ot.getAspects().length > 0)
-                                allowedItems.add(MutablePair.of(is.getItem(), is.getItemDamage()));
-                        }
-                    }
-                    if (ore.equals("cobblestone")) {
-                        for (ItemStack is : OreDictionary.getOres(ore)) {
-                            AspectList ot = ThaumcraftCraftingManager.getObjectTags(is);
-                            ot = ThaumcraftCraftingManager.getBonusTags(is, ot);
-                            if (ot.getAspects().length > 0)
-                                allowedItems.add(MutablePair.of(is.getItem(), is.getItemDamage()));
-                        }
-                    }
-                } else {
-                    allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.stone), OreDictionary.WILDCARD_VALUE));
-                    allowedItems.add(
-                            MutablePair.of(Item.getItemFromBlock(Blocks.cobblestone), OreDictionary.WILDCARD_VALUE));
-                }
-                allowedItems.add(
-                        MutablePair.of(Item.getItemFromBlock(Blocks.mossy_cobblestone), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 0));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 3));
-                allowedItems
-                        .add(MutablePair.of(Item.getItemFromBlock(Blocks.stone_stairs), OreDictionary.WILDCARD_VALUE));
-
-                // All sandstone, stairs, slab
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.sand), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.sandstone), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(
-                        MutablePair.of(Item.getItemFromBlock(Blocks.sandstone_stairs), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 1));
-
-                // All stone bricks, stairs, slab
-                allowedItems
-                        .add(MutablePair.of(Item.getItemFromBlock(Blocks.brick_block), OreDictionary.WILDCARD_VALUE));
-                allowedItems
-                        .add(MutablePair.of(Item.getItemFromBlock(Blocks.brick_stairs), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 5));
-
-                // Bricks, stairs, slab
-                allowedItems
-                        .add(MutablePair.of(Item.getItemFromBlock(Blocks.stonebrick), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(
-                        MutablePair.of(Item.getItemFromBlock(Blocks.stone_brick_stairs), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 4));
-
-                // All quartz, stairs, slab
-                // allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.blockNetherQuartz),OreDictionary.WILDCARD_VALUE));
-                // allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.stairsNetherQuartz),OreDictionary.WILDCARD_VALUE));
-                // allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.stoneSingleSlab),7));
-
-                // Netherbrick, stairs, slab
-                allowedItems
-                        .add(MutablePair.of(Item.getItemFromBlock(Blocks.nether_brick), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(
-                        MutablePair
-                                .of(Item.getItemFromBlock(Blocks.nether_brick_stairs), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 6));
-
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.soul_sand), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.gravel), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.glass), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.grass), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.dirt), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.snow), OreDictionary.WILDCARD_VALUE));
-                allowedItems.add(MutablePair.of(Item.getItemFromBlock(Blocks.clay), OreDictionary.WILDCARD_VALUE));
-                allowedItems
-                        .add(MutablePair.of(Item.getItemFromBlock(Blocks.hardened_clay), OreDictionary.WILDCARD_VALUE));
-            }
-        }
     }
 
     public void addRecipes() {}

--- a/src/main/java/flaxbeard/thaumicexploration/research/ReplicatorRecipes.java
+++ b/src/main/java/flaxbeard/thaumicexploration/research/ReplicatorRecipes.java
@@ -1,0 +1,114 @@
+package flaxbeard.thaumicexploration.research;
+
+import java.util.ArrayList;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import flaxbeard.thaumicexploration.common.ConfigTX;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.config.ConfigBlocks;
+import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
+
+public class ReplicatorRecipes {
+
+    private static final ArrayList<Item> allowedItemsWildcard = new ArrayList<>();
+    private static final ArrayList<ImmutablePair<Item, Integer>> allowedItems = new ArrayList<>();
+    private static final ArrayList<Item> forbiddenItems = new ArrayList<>();
+
+    static {
+        if (!ConfigTX.allowModWoodReplication) {
+            allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.wooden_slab));
+            allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.birch_stairs));
+            allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.oak_stairs));
+            allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.jungle_stairs));
+            allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.spruce_stairs));
+            allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.log));
+            allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.log2));
+            allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.planks));
+        }
+        if (!ConfigTX.allowModStoneReplication) {
+            allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.stone));
+            allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.cobblestone));
+        }
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.mossy_cobblestone));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.stone_stairs));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.sand));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.sandstone));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.sandstone_stairs));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.brick_block));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.brick_stairs));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.stonebrick));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.stone_brick_stairs));
+        // allowedItems.add(Item.getItemFromBlock(Blocks.blockNetherQuartz),OreDictionary.WILDCARD_VALUE));
+        // allowedItems.add(Item.getItemFromBlock(Blocks.stairsNetherQuartz),OreDictionary.WILDCARD_VALUE));
+        // allowedItems.add(Item.getItemFromBlock(Blocks.stoneSingleSlab),7));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.nether_brick));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.nether_brick_stairs));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.soul_sand));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.gravel));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.glass));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.grass));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.dirt));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.snow));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.clay));
+        allowedItemsWildcard.add(Item.getItemFromBlock(Blocks.hardened_clay));
+        allowedItemsWildcard.trimToSize();
+        allowedItems.add(ImmutablePair.of(Item.getItemFromBlock(Blocks.stone), 0));
+        if (!ConfigTX.allowModWoodReplication && ConfigTX.allowMagicPlankReplication) {
+            allowedItems.add(ImmutablePair.of(Item.getItemFromBlock(ConfigBlocks.blockWoodenDevice), 6));
+            allowedItems.add(ImmutablePair.of(Item.getItemFromBlock(ConfigBlocks.blockWoodenDevice), 7));
+        }
+        allowedItems.add(ImmutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 0));
+        allowedItems.add(ImmutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 3));
+        allowedItems.add(ImmutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 1));
+        allowedItems.add(ImmutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 5));
+        allowedItems.add(ImmutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 4));
+        allowedItems.add(ImmutablePair.of(Item.getItemFromBlock(Blocks.stone_slab), 6));
+        allowedItems.trimToSize();
+        forbiddenItems.add(Item.getItemFromBlock(ConfigBlocks.blockMagicalLog));
+        forbiddenItems.add(Item.getItemFromBlock(ConfigBlocks.blockMagicalLeaves));
+        if (ConfigTX.allowModWoodReplication && !ConfigTX.allowMagicPlankReplication) {
+            forbiddenItems.add(Item.getItemFromBlock(ConfigBlocks.blockWoodenDevice));
+        }
+        forbiddenItems.trimToSize();
+    }
+
+    public static boolean canStackBeReplicated(ItemStack stack) {
+        Item item = stack.getItem();
+        if (allowedItemsWildcard.contains(item)) {
+            return true;
+        }
+        if (allowedItems.contains(ImmutablePair.of(item, stack.getItemDamage()))) {
+            return true;
+        }
+        if (forbiddenItems.contains(item)) {
+            return false;
+        }
+        int[] oreIDs = OreDictionary.getOreIDs(stack);
+        for (int id : oreIDs) {
+            String oreName = OreDictionary.getOreName(id);
+            if (checkOreDictRules(oreName)) {
+                AspectList ot = ThaumcraftCraftingManager.getObjectTags(stack);
+                ot = ThaumcraftCraftingManager.getBonusTags(stack, ot);
+                if (ot.getAspects().length > 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean checkOreDictRules(String oreName) {
+        return oreName != null && (oreName.equals("logWood") || oreName.equals("treeLeaves")
+                || oreName.equals("slabWood")
+                || oreName.equals("stairWood")
+                || ConfigTX.allowModStoneReplication && (oreName.equals("stone") || oreName.equals("cobblestone"))
+                || ConfigTX.allowModWoodReplication && oreName.equals("plankWood"));
+    }
+
+}


### PR DESCRIPTION
This mod adds a block that allows you to replicate various items from the game.

To recognize which items are allowed or not, it loops during game start on all the items and metas in the ore dicts and adds them to a cache list following certain rules. This is stupid it could just check for theses rules when using the block instead of filling a cache with every combination possible.

Furthermore it fails at creating a cache properly since :
- on every iteration it adds the same static items that have nothing to do with the loop
- it creates the cache both on server and client when it's only needed on the server
- it creates the cache on game start even you are never going to use this block

This results in a 40 MB List with more than 1 million elements.

![image](https://github.com/user-attachments/assets/8585d3c4-0fac-4647-8e86-db787bdd2288)


In this PR I completely remove the cache and only check for the logic when the block is used.