### PR TITLE
Soul Brazier fixes.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.27'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.28'
 }
 
 

--- a/src/main/java/flaxbeard/thaumicexploration/tile/TileEntitySoulBrazier.java
+++ b/src/main/java/flaxbeard/thaumicexploration/tile/TileEntitySoulBrazier.java
@@ -307,9 +307,10 @@ public class TileEntitySoulBrazier extends TileVisRelay implements IEssentiaTran
 
     @Override
     public void forceChunkLoading(ForgeChunkManager.Ticket ticket) {
-
-        this.heldChunk = ticket;
-        ForgeChunkManager.forceChunk(this.heldChunk, new ChunkCoordIntPair(this.xCoord >> 4, this.zCoord >> 4));
+        if (ConfigTX.allowSBChunkLoading) {
+            this.heldChunk = ticket;
+            ForgeChunkManager.forceChunk(this.heldChunk, new ChunkCoordIntPair(this.xCoord >> 4, this.zCoord >> 4));
+        }
     }
 
     @Override

--- a/src/main/java/flaxbeard/thaumicexploration/tile/TileEntitySoulBrazier.java
+++ b/src/main/java/flaxbeard/thaumicexploration/tile/TileEntitySoulBrazier.java
@@ -164,19 +164,11 @@ public class TileEntitySoulBrazier extends TileVisRelay implements IEssentiaTran
                 .getConnectableTile(this.worldObj, this.xCoord, this.yCoord, this.zCoord, ForgeDirection.DOWN);
         if (te != null) {
             IEssentiaTransport ic = (IEssentiaTransport) te;
-            if (!ic.canOutputTo(ForgeDirection.UP)) {
-                return;
-            }
-
             Aspect ta = Aspect.DEATH;
-            if ((ic.getEssentiaAmount(ForgeDirection.UP) > 0)
-                    && (ic.getSuctionAmount(ForgeDirection.UP) < getSuctionAmount(ForgeDirection.DOWN))
-                    && (getSuctionAmount(ForgeDirection.DOWN) >= ic.getMinimumSuction())) {
-                ta = ic.getEssentiaType(ForgeDirection.UP);
-            }
-
-            if ((ta != null) && (ic.getSuctionAmount(ForgeDirection.UP) < getSuctionAmount(ForgeDirection.DOWN)))
+            if (ic.canOutputTo(ForgeDirection.UP)
+                    && ic.getSuctionAmount(ForgeDirection.UP) < getSuctionAmount(ForgeDirection.DOWN)) {
                 addEssentia(ta, ic.takeEssentia(ta, 1, ForgeDirection.UP), ForgeDirection.DOWN);
+            }
         }
     }
 

--- a/src/main/java/flaxbeard/thaumicexploration/tile/TileEntitySoulBrazier.java
+++ b/src/main/java/flaxbeard/thaumicexploration/tile/TileEntitySoulBrazier.java
@@ -170,8 +170,8 @@ public class TileEntitySoulBrazier extends TileVisRelay implements IEssentiaTran
 
             Aspect ta = Aspect.DEATH;
             if ((ic.getEssentiaAmount(ForgeDirection.UP) > 0)
-                    && (ic.getSuctionAmount(ForgeDirection.UP) < getSuctionAmount(ForgeDirection.UP))
-                    && (getSuctionAmount(ForgeDirection.UP) >= ic.getMinimumSuction())) {
+                    && (ic.getSuctionAmount(ForgeDirection.UP) < getSuctionAmount(ForgeDirection.DOWN))
+                    && (getSuctionAmount(ForgeDirection.DOWN) >= ic.getMinimumSuction())) {
                 ta = ic.getEssentiaType(ForgeDirection.UP);
             }
 


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17832, brazier now correctly turns off chunkloading when the config value is changed from `true` to `false`. Probably still requires server restart.

Fixes a bug where the brazier was pulling essentia suction from the wrong side, causing it to act as if it had a suction of 0 and being unable to pull essentia from longer tube networks properly.

Fixes a bug where it was in some cases possible to get the brazier to run on any aspect of essentia, not only Mortuus.