### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/thaumicexploration/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicexploration/lang/en_US.lang
@@ -35,7 +35,7 @@ thaumicexploration.bread2=Are you feeling hungry?
 thaumicexploration.bread3=Bonjour, monsieur.
 thaumicexploration.bread4=Mangez-moi, s'il vous plait.
 
-
+item.thaumicexploration:discountRing.name=Ring
 item.thaumicexploration:discountRing:0.name=Ring of Aer
 item.thaumicexploration:discountRing:1.name=Ring of Terra
 item.thaumicexploration:discountRing:2.name=Ring of Ignis
@@ -103,6 +103,7 @@ item.thaumicexploration:blankSeal:Red.name=Red Blank Seal
 item.thaumicexploration:blankSeal:Dark.name=Dark Blank Seal
 
 ----Chest Seals----
+item.thaumicexploration:chestSeal.name=Chest Binding Seal
 item.thaumicexploration:chestSeal:Pale.name=Pale Chest Binding Seal
 item.thaumicexploration:chestSeal:Orange.name=Orange Chest Binding Seal
 item.thaumicexploration:chestSeal:Magenta.name=Magenta Chest Binding Seal
@@ -121,6 +122,7 @@ item.thaumicexploration:chestSeal:Red.name=Red Chest Binding Seal
 item.thaumicexploration:chestSeal:Dark.name=Dark Chest Binding Seal
 
 ----Jar Seals----
+item.thaumicexploration:jarSeal.name=Jar Binding Seal
 item.thaumicexploration:jarSeal:Pale.name=Pale Jar Binding Seal
 item.thaumicexploration:jarSeal:Orange.name=Orange Jar Binding Seal
 item.thaumicexploration:jarSeal:Magenta.name=Magenta Jar Binding Seal
@@ -148,6 +150,7 @@ tile.thaumicexploration:trashJar.name=Oblivion Jar
 tile.thaumicexploration:soulBrazier.name=Soul Brazier
 tile.boundJar.name=Bound Jar
 tile.boundChest.name=Bound Chest
+tile.thaumicexploration:floatCandle.name=Floating Candle
 tile.thaumicexploration:floatCandle.0.name=White Floating Candle
 tile.thaumicexploration:floatCandle.1.name=Orange Floating Candle
 tile.thaumicexploration:floatCandle.2.name=Magenta Floating Candle


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.