### PR TITLE
Baguette Wand Core Research

### DIFF
--- a/src/main/java/flaxbeard/thaumicexploration/research/ModResearch.java
+++ b/src/main/java/flaxbeard/thaumicexploration/research/ModResearch.java
@@ -507,10 +507,17 @@ public final class ModResearch {
         research.setPages(new ResearchPage("1"), infusionPage("ROD_NECROMANCER_staff"));
 
         if (ConfigTX.breadWand) {
-            // research = new TXResearchItem("ROD_BREAD", "THAUMATURGY", new AspectList().add(Aspect.MAGIC,
-            // 5).add(Aspect.CROP, 3).add(Aspect.HUNGER, 4).add(Aspect.HARVEST, 3), -11, 0, 1, new
-            // ItemStack(ThaumicExploration.breadCore)).setParents("ROD_AMBER").setConcealed().registerResearchItem().setSecondary();
-            // research.setPages(new ResearchPage("1"), infusionPage("ROD_BREAD"));
+            research = new TXResearchItem(
+                    "ROD_BREAD",
+                    "TX",
+                    new AspectList().add(Aspect.MAGIC, 5).add(Aspect.CROP, 3).add(Aspect.HUNGER, 4)
+                            .add(Aspect.HARVEST, 3),
+                    -3,
+                    -1,
+                    1,
+                    new ItemStack(ThaumicExploration.breadCore)).setParents("TXROD_greatwood", "INFUSION")
+                            .setConcealed().registerResearchItem().setSecondary();
+            research.setPages(new ResearchPage("1"), infusionPage("ROD_BREAD"));
         }
 
         // Sealery


### PR DESCRIPTION
This wand is locked behind the config `B:"Enable Thaumic Frenchurgy"=true`. It has a vis storage of 39 and sends messages in chat asking you to eat it. Without this research, it is uncraftable and unusable, which cannot stand. I changed it from requiring the Amber Core research; now it requires Infusion and the Greatwood Core research as prereqs. I also moved it from the Thaumaturgy tab to fit with the rest of the cores added by TX.

<img width="946" height="799" alt="image" src="https://github.com/user-attachments/assets/cd4d765b-9787-47b7-ac92-9092b40cc425" />
