### PR TITLE
Fix NPE on Talisman of Nutrition

### DIFF
--- a/src/main/java/flaxbeard/thaumicexploration/item/ItemFoodTalisman.java
+++ b/src/main/java/flaxbeard/thaumicexploration/item/ItemFoodTalisman.java
@@ -65,9 +65,8 @@ public class ItemFoodTalisman extends Item {
             setDefaultTags(talisman);
             tryAbsorbFood(talisman, player, world);
             tryFeedPlayer(talisman, player);
+            talisman.setItemDamage(talisman.getMaxDamage() - talisman.stackTagCompound.getInteger("nourishment"));
         }
-
-        talisman.setItemDamage(talisman.getMaxDamage() - talisman.stackTagCompound.getInteger("nourishment"));
     }
 
     private void tryAbsorbFood(ItemStack talisman, EntityPlayer player, World world) {

--- a/src/main/java/flaxbeard/thaumicexploration/item/ItemFoodTalisman.java
+++ b/src/main/java/flaxbeard/thaumicexploration/item/ItemFoodTalisman.java
@@ -55,11 +55,9 @@ public class ItemFoodTalisman extends Item {
 
     @Override
     public void onUpdate(ItemStack talisman, World world, Entity entity, int slot, boolean isSelected) {
-        if (!(entity instanceof EntityPlayer) || entity.ticksExisted % 20 != 0) {
+        if (!(entity instanceof EntityPlayer player) || entity.ticksExisted % 20 != 0) {
             return;
         }
-
-        EntityPlayer player = (EntityPlayer) entity;
 
         if (!world.isRemote) {
             setDefaultTags(talisman);


### PR DESCRIPTION
Talisman of Nutrition would NPE when spawning one in. I don't know why this didn't come up in my previous testing working on the item. Did something with tooltips change something?