### PR TITLE
Talisman of Nourishment: grant Nutrition nutrients from stored food

### DIFF
--- a/src/main/java/flaxbeard/thaumicexploration/interop/AppleCoreInterop.java
+++ b/src/main/java/flaxbeard/thaumicexploration/interop/AppleCoreInterop.java
@@ -23,12 +23,25 @@ public class AppleCoreInterop {
 
     public static void setHunger(int hunger, EntityPlayer player) {
         AppleCoreAPI.mutator.setHunger(player, player.getFoodStats().getFoodLevel() + hunger);
-        MinecraftForge.EVENT_BUS.post(new FoodEvent.FoodStatsAddition(player, new FoodValues(hunger, 0)));
+    }
+
+    /**
+     * Notifies that the food was actually consumed, so mods like Nutrition can grant its nutrients. Both events are
+     * posted in the same order vanilla eating posts them, as listeners may expect them to come in pairs.
+     */
+    public static void postFoodEaten(ItemStack food, EntityPlayer player) {
+        FoodValues values = AppleCoreAPI.accessor.getFoodValues(food);
+        MinecraftForge.EVENT_BUS.post(new FoodEvent.FoodStatsAddition(player, values));
+        MinecraftForge.EVENT_BUS.post(
+                new FoodEvent.FoodEaten(
+                        player,
+                        food,
+                        values,
+                        values.hunger,
+                        values.hunger * values.saturationModifier * 2f));
     }
 
     public static void setSaturation(float saturation, EntityPlayer player) {
         AppleCoreAPI.mutator.setSaturation(player, player.getFoodStats().getSaturationLevel() + saturation);
-        // We only post the FoodStatsAddition event for nutrition, which ignores it if the hunger didn't increase
-        // so there's no need to post it here
     }
 }

--- a/src/main/java/flaxbeard/thaumicexploration/item/ItemFoodTalisman.java
+++ b/src/main/java/flaxbeard/thaumicexploration/item/ItemFoodTalisman.java
@@ -14,6 +14,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.potion.Potion;
 import net.minecraft.util.FoodStats;
 import net.minecraft.world.World;
@@ -30,6 +31,7 @@ public class ItemFoodTalisman extends Item {
 
     private static final String[] ALL_FOOD_BLACKLIST_NAMES = { ConfigItems.itemManaBean.getUnlocalizedName(),
             ConfigItems.itemZombieBrain.getUnlocalizedName(), "item.foodstuff.0.name", "ic2.itemterrawart", };
+    private static final String FOOD_QUEUE_TAG = "foodQueue";
     public static List<String> foodBlacklist = new ArrayList<String>();
     public static Map<String, Boolean> foodCache = new HashMap<String, Boolean>();
     private final int MAX_NOURISHMENT_SIZE_TALISMAN = 1000;
@@ -62,7 +64,11 @@ public class ItemFoodTalisman extends Item {
         if (!world.isRemote) {
             setDefaultTags(talisman);
             tryAbsorbFood(talisman, player, world);
+
+            int before = talisman.stackTagCompound.getInteger("nourishment");
             tryFeedPlayer(talisman, player);
+            consumeQueuedFood(talisman, player, before - talisman.stackTagCompound.getInteger("nourishment"));
+
             talisman.setItemDamage(talisman.getMaxDamage() - talisman.stackTagCompound.getInteger("nourishment"));
         }
     }
@@ -90,7 +96,9 @@ public class ItemFoodTalisman extends Item {
             }
 
             int foodNourishment = Math.round((saturation + heal) / 2);
-            nourishment = Math.min(nourishment + foodNourishment, MAX_NOURISHMENT_SIZE_TALISMAN);
+            int newNourishment = Math.min(nourishment + foodNourishment, MAX_NOURISHMENT_SIZE_TALISMAN);
+            queueFood(talisman, food, newNourishment - nourishment);
+            nourishment = newNourishment;
             talisman.stackTagCompound.setInteger("nourishment", nourishment);
 
             if (food.stackSize <= 1) {
@@ -146,6 +154,81 @@ public class ItemFoodTalisman extends Item {
         }
 
         talisman.stackTagCompound.setInteger("nourishment", Math.max(nourishment, 0));
+    }
+
+    /**
+     * Remembers which food produced the stored nourishment, so that nutrient-tracking mods can be notified only when
+     * that nourishment is actually spent on the player.
+     */
+    private void queueFood(ItemStack talisman, ItemStack food, int points) {
+        if (points <= 0 || !Loader.isModLoaded("AppleCore")) {
+            return;
+        }
+
+        ItemStack single = food.copy();
+        single.stackSize = 1;
+
+        NBTTagList queue = talisman.stackTagCompound.getTagList(FOOD_QUEUE_TAG, 10);
+        for (int i = 0; i < queue.tagCount(); i++) {
+            NBTTagCompound entry = queue.getCompoundTagAt(i);
+            ItemStack queued = ItemStack.loadItemStackFromNBT(entry.getCompoundTag("item"));
+            if (entry.getInteger("points") == points && ItemStack.areItemStacksEqual(queued, single)) {
+                entry.setInteger("units", entry.getInteger("units") + 1);
+                talisman.stackTagCompound.setTag(FOOD_QUEUE_TAG, queue);
+                return;
+            }
+        }
+
+        NBTTagCompound item = new NBTTagCompound();
+        single.writeToNBT(item);
+        NBTTagCompound entry = new NBTTagCompound();
+        entry.setTag("item", item);
+        entry.setInteger("points", points);
+        entry.setInteger("units", 1);
+        queue.appendTag(entry);
+        talisman.stackTagCompound.setTag(FOOD_QUEUE_TAG, queue);
+    }
+
+    /**
+     * Posts one FoodEaten event per queued food that the given amount of spent nourishment covers.
+     */
+    private void consumeQueuedFood(ItemStack talisman, EntityPlayer player, int spent) {
+        if (spent <= 0 || !Loader.isModLoaded("AppleCore")) {
+            return;
+        }
+
+        NBTTagList queue = talisman.stackTagCompound.getTagList(FOOD_QUEUE_TAG, 10);
+        while (spent > 0 && queue.tagCount() > 0) {
+            NBTTagCompound entry = queue.getCompoundTagAt(0);
+            int points = entry.getInteger("points");
+            int units = entry.getInteger("units");
+            if (points <= 0 || units <= 0) {
+                queue.removeTag(0);
+                continue;
+            }
+
+            int progress = entry.getInteger("progress") + spent;
+            int eaten = Math.min(progress / points, units);
+            if (eaten > 0) {
+                ItemStack food = ItemStack.loadItemStackFromNBT(entry.getCompoundTag("item"));
+                if (food != null) {
+                    for (int i = 0; i < eaten; i++) {
+                        AppleCoreInterop.postFoodEaten(food, player);
+                    }
+                }
+            }
+
+            int leftover = progress - eaten * points;
+            if (eaten >= units) {
+                queue.removeTag(0);
+                spent = leftover; // carry the remainder over to the next queued food
+            } else {
+                entry.setInteger("units", units - eaten);
+                entry.setInteger("progress", leftover);
+                spent = 0;
+            }
+        }
+        talisman.stackTagCompound.setTag(FOOD_QUEUE_TAG, queue);
     }
 
     private void setDefaultTags(ItemStack talisman) {


### PR DESCRIPTION
## Summary
The talisman fed hunger directly through the AppleCore mutator and posted only FoodStatsAddition, which Nutrition classifies as a non-food stat change. That gave no nutrients at all, and a player living off the talisman was left with nutrition slowly decaying and never being restored.

The talisman now records which food produced the stored nourishment in its NBT, and posts the vanilla FoodStatsAddition/FoodEaten pair for each food once the nourishment it provided is actually spent on the player. Nutrients therefore come from the food that was absorbed, and a player who is not hungry gains nothing until the talisman feeds them.

Talismans charged before this change have no recorded food, so their remaining nourishment is spent without granting nutrients.


## Checklist
- [ ] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
